### PR TITLE
Fix missing const declaration

### DIFF
--- a/index.js
+++ b/index.js
@@ -104,6 +104,7 @@ export const VueHammer = {
         }
       },
       unbind(el, binding) {
+        const mc = el.hammer
         if (mc.handler) {
           el.hammer.off(binding.arg, mc.handler)
         }


### PR DESCRIPTION
While using the component I noticed an error when the custom directive was destroyed. Looking at the code I noticed the mc constant was not being declared in the unbind block of the directive. I added it and everything runs smoothly.