### PR TITLE
fix : Global configuration is not adapted

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,7 +21,10 @@ export const VueHammer = {
         if (!event) {
           console.warn('[vue-hammer] event type argument is required.')
         }
-        that.config[event] = {}
+       
+        if(!that.config[event]){  
+          that.config[event] = {}
+        }
 
         const direction = binding.modifiers
         if (!isEmpty(direction)) {


### PR DESCRIPTION
If I use global recognizer configuration, it's not applied. ( example below )

```
VueHammer.config.press = { time: 1000 }
Vue.use(VueHammer)
```

because,
```
that.config[event] = {}
```
this code line override user's setting.


