### PR TITLE
Add requireFailure for custom events

### DIFF
--- a/index.js
+++ b/index.js
@@ -46,6 +46,17 @@ export const VueHammer = {
           recognizer = new Hammer[this.capitalize(recognizerType)](custom)
           recognizer.recognizeWith(mc.recognizers)
           mc.add(recognizer)
+
+          // add requireFailure for custom event
+          if (custom.requireFailure) {
+            let requiredFailures = mc.recognizers.filter(
+              recognizerItem =>
+                custom.requireFailure.includes(recognizerItem.options.event)
+            );
+            requiredFailures.forEach(
+              requiredFailure => recognizer.requireFailure(requiredFailure)
+            )
+          }
         } else {
           // built-in event
           recognizerType = gestures.find(gesture => gesture === event)


### PR DESCRIPTION
If you need to set single tap and double tap on one element, you have to set requireFailure option for Hammer (http://hammerjs.github.io/require-failure/)

```
var hammer = new Hammer(el, {});

var singleTap = new Hammer.Tap({ event: 'singletap' });
var doubleTap = new Hammer.Tap({event: 'doubletap', taps: 2 });
var tripleTap = new Hammer.Tap({event: 'tripletap', taps: 3 });

hammer.add([tripleTap, doubleTap, singleTap]);

tripleTap.recognizeWith([doubleTap, singleTap]);
doubleTap.recognizeWith(singleTap);

doubleTap.requireFailure(tripleTap);
singleTap.requireFailure([tripleTap, doubleTap]);
```

So, I added parsing a requireFailure option for custom events

```
import { VueHammer } from 'vue2-hammer';
VueHammer.customEvents = {
  doubletap: { type: 'tap', event: 'doubletap', taps: 2 },
  singletap: { type: 'tap', event: 'singletap', requireFailure: ['doubletap'] }
};
Vue.use(VueHammer);
```